### PR TITLE
Make flathub responsible of the build files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scoreboard"]
+	path = scoreboard
+	url = https://github.com/metal3d/scoreboard.git

--- a/org.metal3d.scoreboard.appdata.xml
+++ b/org.metal3d.scoreboard.appdata.xml
@@ -64,13 +64,19 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.1.0-1" date="2023-09-10" type="stable">
+      <description>
+          <p>Minor changes. Enhancements for flathub build.</p>
+      </description>
+      <url type="details">https://github.com/metal3d/scoreboard/releases/tag/v1.1.0-1</url>
+    </release>
     <release version="1.1.0" date="2023-09-09" type="stable">
       <description>
         <p>Fixes and i18n.</p>
         <p>Add French translation.</p>
         <p>Make the focus on the next entry when the score is validated.</p>
       </description>
-      <url type="details">https://github.com/metal3d/scoreboard/releases/tag/v1.0.1</url>
+      <url type="details">https://github.com/metal3d/scoreboard/releases/tag/v1.1.0</url>
     </release>
     <release version="1.0.0" date="2023-08-31" type="stable">
       <description>

--- a/org.metal3d.scoreboard.appdata.xml
+++ b/org.metal3d.scoreboard.appdata.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.metal3d.scoreboard</id>
+  
+  <name>Scoreboard</name>
+  <developer_name>Patrice Ferlet</developer_name>
+  
+  <summary>A simple scoreboard to count points for any game</summary>
+  <summary xml:lang="fr">Un simple compteur de points pour n'importe quel jeu</summary>
+  
+  <categories>
+    <category>Game</category>
+    <category>Utility</category>
+  </categories>
+  
+  <languages>
+    <lang>en</lang>
+    <lang>fr</lang>
+  </languages>
+  
+  <metadata_license>MIT</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+
+  <keywords>
+    <keyword>game</keyword>
+    <keyword xml:lang="fr">jeu</keyword>
+    <keyword>score</keyword>
+    <keyword>points</keyword>
+  </keywords>
+  
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </recommends>
+  
+  <description>
+      <p>This is a simple utility to count points while you're playing a game. Simply add some players, order them, and then start to count your scores.</p>
+      <p>It's a very simple tool, made with Fyne.io and Go.</p>
+      <p xml:lang="fr">Simple utilitaire pour compter les points pendant que vous jouez à un jeu. Ajoutez simplement des joueurs, ordonnez les, puis démarrez le comptage de points.</p>
+      <p xml:lang="fr">C'est un outil très simple, fait avec Fyne.io et Go.</p>
+  </description>
+  
+  <launchable type="desktop-id">org.metal3d.scoreboard.desktop</launchable>
+  <screenshots>
+    <screenshot>
+        <image>https://github.com/metal3d/scoreboard/blob/main/captures/0-index.png?raw=true</image>
+    </screenshot>
+    <screenshot>
+        <image>https://github.com/metal3d/scoreboard/blob/main/captures/1-game.png?raw=true</image>
+    </screenshot>
+    <screenshot>
+        <image>https://github.com/metal3d/scoreboard/blob/main/captures/2-players.png?raw=true</image>
+    </screenshot>
+    <screenshot>
+        <image>https://github.com/metal3d/scoreboard/blob/main/captures/3-scores.png?raw=true</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="bugtracker">https://github.com/metal3d/scoreboard/issues</url>
+  <url type="homepage">https://github.com/metal3d/scoreboard</url>
+
+  <!-- Generate the oars rating at: https://hughsie.github.io/oars/generate.html -->
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="1.1.0" date="2023-09-09" type="stable">
+      <description>
+        <p>Fixes and i18n.</p>
+        <p>Add French translation.</p>
+        <p>Make the focus on the next entry when the score is validated.</p>
+      </description>
+      <url type="details">https://github.com/metal3d/scoreboard/releases/tag/v1.0.1</url>
+    </release>
+    <release version="1.0.0" date="2023-08-31" type="stable">
+      <description>
+        <p>The first version.</p>
+      </description>
+      <url type="details">https://github.com/metal3d/scoreboard/releases/tag/v1.0.0</url>
+    </release>
+  </releases>
+
+</component>

--- a/org.metal3d.scoreboard.desktop
+++ b/org.metal3d.scoreboard.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Scoreboard
+Comment=A simple Scoreboard to count points for any game.
+Categories=Game;Utility;
+Icon=org.metal3d.scoreboard
+Exec=scoreboard
+Terminal=false

--- a/org.metal3d.scoreboard.yaml
+++ b/org.metal3d.scoreboard.yaml
@@ -21,12 +21,15 @@ modules:
   - name: scoreboard
     buildsystem: simple
     build-commands:
-      - $GOROOT/bin/go build -trimpath -o scoreboard -ldflags "-X scoreboard/version.appVersion=1.1.0-flathub" .
+      - $GOROOT/bin/go build -trimpath -o scoreboard -ldflags "-X scoreboard/version.appVersion=1.1.0-2-flathub" .
       - install -Dm00755 scoreboard $FLATPAK_DEST/bin/scoreboard
       - install -Dm00644 Icon.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
       - install -Dm00644 $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
       - install -Dm00644 $FLATPAK_ID.appdata.xml $FLATPAK_DEST/share/appdata/$FLATPAK_ID.appdata.xml
     sources:
-      - type: archive
-        url: "https://github.com/metal3d/scoreboard/archive/refs/tags/v1.1.0.tar.gz"
-        sha256: "17c7a6fc25cc91d62faf59c3685c6a32a64cf4795d454fab909f33d28320b4ef"
+      - type: file
+        path: org.metal3d.scoreboard.appdata.xml
+      - type: file
+        path: org.metal3d.scoreboard.desktop
+      - type: dir
+        path: ./scoreboard


### PR DESCRIPTION
Move all flathub files to this repository instead of keeping them in the original project. Use git submodules to point the right version.

Try to build this.